### PR TITLE
Defer setup to avoid module import-time side-effects

### DIFF
--- a/library/phatbeat/__init__.py
+++ b/library/phatbeat/__init__.py
@@ -6,7 +6,7 @@ from sys import exit
 try:
     import RPi.GPIO as GPIO
 except ImportError:
-    exit("This library requires the RPi.GPIO module\nInstall with: sudo pip install RPi.GPIO")
+    raise ImportError("This library requires the RPi.GPIO module\nInstall with: sudo pip install RPi.GPIO")
 
 
 __version__ = '0.0.2'
@@ -37,6 +37,7 @@ _button_hold_repeat = {}
 
 _use_threading = False
 
+_is_setup = False
 _clear_on_exit = True
 
 def _exit():
@@ -47,6 +48,7 @@ def _exit():
 
 def use_threading(value=True):
     global _use_threading
+    ensure_setup()
     _use_threading = value
 
 def hold(buttons, handler=None, repeat=True, hold_time=2):
@@ -60,6 +62,8 @@ def hold(buttons, handler=None, repeat=True, hold_time=2):
     :param hold_time: How long (in seconds) the button should be held before triggering
 
     """
+
+    ensure_setup()
 
     buttons = buttons if isinstance(buttons, list) else [buttons]
 
@@ -89,6 +93,8 @@ def on(buttons, handler=None, repeat=True):
 
     """
 
+    ensure_setup()
+
     buttons = buttons if isinstance(buttons, list) else [buttons]
 
     for button in buttons:
@@ -112,6 +118,8 @@ def set_brightness(brightness, channel = None):
 
     """
 
+    ensure_setup()
+
     if brightness < 0 or brightness > 1:
         raise ValueError("Brightness should be between 0.0 and 1.0")
 
@@ -125,6 +133,8 @@ def set_brightness(brightness, channel = None):
 
 def clear(channel = None):
     """Clear the pixel buffer"""
+
+    ensure_setup()
 
     if channel is None or channel == 0:
         for x in range(CHANNEL_PIXELS):
@@ -205,6 +215,8 @@ def _do_handle_button(pin):
 def show():
     """Output the buffer to the displays"""
 
+    ensure_setup()
+
     _sof()
 
     for pixel in pixels:
@@ -229,6 +241,8 @@ def set_all(r, g, b, brightness=None, channel=None):
 
     """
 
+    ensure_setup()
+
     if channel is None or channel == 0:
         for x in range(CHANNEL_PIXELS):
             set_pixel(x, r, g, b, brightness)
@@ -250,6 +264,8 @@ def set_pixel(x, r, g, b, brightness=None, channel=None):
     :param channel: Optionally specify which bar to set: 0 or 1
 
     """
+
+    ensure_setup()
 
     if brightness is None:
         brightness = pixels[x][3]
@@ -282,14 +298,30 @@ def set_clear_on_exit(value=True):
     """
 
     global _clear_on_exit
+    ensure_setup()
     _clear_on_exit = value
 
-atexit.register(_exit)
+def ensure_setup():
+    return setup()
 
-GPIO.setmode(GPIO.BCM)
-GPIO.setwarnings(False)
-GPIO.setup([DAT,CLK],GPIO.OUT)
-GPIO.setup(BUTTONS, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+def setup():
+    global _is_setup, ensure_setup
 
-for button in BUTTONS:
-    GPIO.add_event_detect(button, GPIO.FALLING, callback=_handle_button, bouncetime=200)
+    if _is_setup:
+        raise RuntimeError("Setup has already run,\nplease call phatbeat.setup() before any other method.")
+
+    def ensure_setup():
+        return True
+
+    atexit.register(_exit)
+
+    GPIO.setmode(GPIO.BCM)
+    GPIO.setwarnings(False)
+    GPIO.setup([DAT,CLK],GPIO.OUT)
+    GPIO.setup(BUTTONS, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+    for button in BUTTONS:
+        GPIO.add_event_detect(button, GPIO.FALLING, callback=_handle_button, bouncetime=200)
+
+    _is_setup = True
+

--- a/library/phatbeat/__init__.py
+++ b/library/phatbeat/__init__.py
@@ -48,7 +48,7 @@ def _exit():
 
 def use_threading(value=True):
     global _use_threading
-    ensure_setup()
+    setup()
     _use_threading = value
 
 def hold(buttons, handler=None, repeat=True, hold_time=2):
@@ -63,7 +63,7 @@ def hold(buttons, handler=None, repeat=True, hold_time=2):
 
     """
 
-    ensure_setup()
+    setup()
 
     buttons = buttons if isinstance(buttons, list) else [buttons]
 
@@ -93,7 +93,7 @@ def on(buttons, handler=None, repeat=True):
 
     """
 
-    ensure_setup()
+    setup()
 
     buttons = buttons if isinstance(buttons, list) else [buttons]
 
@@ -118,7 +118,7 @@ def set_brightness(brightness, channel = None):
 
     """
 
-    ensure_setup()
+    setup()
 
     if brightness < 0 or brightness > 1:
         raise ValueError("Brightness should be between 0.0 and 1.0")
@@ -134,7 +134,7 @@ def set_brightness(brightness, channel = None):
 def clear(channel = None):
     """Clear the pixel buffer"""
 
-    ensure_setup()
+    setup()
 
     if channel is None or channel == 0:
         for x in range(CHANNEL_PIXELS):
@@ -215,7 +215,7 @@ def _do_handle_button(pin):
 def show():
     """Output the buffer to the displays"""
 
-    ensure_setup()
+    setup()
 
     _sof()
 
@@ -241,7 +241,7 @@ def set_all(r, g, b, brightness=None, channel=None):
 
     """
 
-    ensure_setup()
+    setup()
 
     if channel is None or channel == 0:
         for x in range(CHANNEL_PIXELS):
@@ -265,7 +265,7 @@ def set_pixel(x, r, g, b, brightness=None, channel=None):
 
     """
 
-    ensure_setup()
+    setup()
 
     if brightness is None:
         brightness = pixels[x][3]
@@ -298,19 +298,14 @@ def set_clear_on_exit(value=True):
     """
 
     global _clear_on_exit
-    ensure_setup()
+    setup()
     _clear_on_exit = value
 
-def ensure_setup():
-    return setup()
 
 def setup():
-    global _is_setup, ensure_setup
+    global _is_setup
 
     if _is_setup:
-        raise RuntimeError("Setup has already run,\nplease call phatbeat.setup() before any other method.")
-
-    def ensure_setup():
         return True
 
     atexit.register(_exit)


### PR DESCRIPTION
This PR makes several "friendly neighbour" changes to the pHAT BEAT library:

* Do not perform any module setup on import
* Do not output any messages/text on import
* Use ImportError instead of hard exit() for "friendly" import error messages

See here for details of the problems import-time side-effects can have: https://www.raspberrypi.org/forums/viewtopic.php?f=32&t=193502&p=1212488#p1212488