### PR TITLE
Add the sleep timer function

### DIFF
--- a/projects/vlc-radio/phatbeatd/usr/bin/phatbeatd
+++ b/projects/vlc-radio/phatbeatd/usr/bin/phatbeatd
@@ -219,6 +219,12 @@ if __name__ == "__main__":
             log(vlc.communicate("pause"))
             os.system("sudo shutdown -h now")
 
+        @phatbeat.hold(phatbeat.BTN_ONOFF)
+        def delay_shutdown(pin):
+            time.sleep(1200)
+            log(vlc.communicate("pause"))
+            os.system("sudo shutdown -h now")
+
         signal.signal(signal.SIGINT, _signal_handler)
         signal.signal(signal.SIGTERM, _signal_handler)
         signal.pause()


### PR DESCRIPTION
When holding the power off button for 2 seconds, the pirate radio will shut down with a delay of 20 minutes.